### PR TITLE
Implement DirectX rendering infrastructure

### DIFF
--- a/SlicerCore/src/Rendering/MainView.cpp
+++ b/SlicerCore/src/Rendering/MainView.cpp
@@ -1,5 +1,6 @@
+#include "pch.h"
 #include "MainView.h"
-#include "../../Public/SlicerCoreAPI.h" 
+#include "../../Public/SlicerCoreAPI.h"
 #include "../../src/Rendering/RenderBasics/Direct3D.h"
 
 using namespace Direct3D;
@@ -24,14 +25,28 @@ HRESULT createMainView(HWND hWnd, iMainView** ppView)
 
 HRESULT __stdcall MainView::render()
 {
-    // Your rendering logic will go here.
-    // For now, let's just clear the screen.
+    // For now simply clear the render target.
     float clearColor[] = { 0.1f, 0.2f, 0.3f, 1.0f };
 
-    // Use the global context pointer from Direct3D.h
     if (Direct3D::context && m_renderTargetView)
     {
-        Direct3D::context->ClearRenderTargetView(m_renderTargetView.Get(), clearColor);
+        CComCritSecLock<CComAutoCriticalSection> lock(g_contextLock);
+
+        ID3D11RenderTargetView* rtv = m_renderTargetView.Get();
+        Direct3D::context->OMSetRenderTargets(1, &rtv, m_depthStencilView.Get());
+
+        D3D11_VIEWPORT vp = {};
+        vp.Width = static_cast<float>(m_width);
+        vp.Height = static_cast<float>(m_height);
+        vp.MaxDepth = 1.0f;
+        Direct3D::context->RSSetViewports(1, &vp);
+
+        Direct3D::context->ClearRenderTargetView(rtv, clearColor);
+        if (m_depthStencilView)
+            Direct3D::context->ClearDepthStencilView(m_depthStencilView.Get(),
+                D3D11_CLEAR_DEPTH | D3D11_CLEAR_STENCIL, 1.0f, 0);
+
+        Direct3D::context->Flush();
     }
 
     return S_OK;
@@ -54,6 +69,7 @@ HRESULT __stdcall MainView::getSurface(void** ppSurface)
 
 HRESULT __stdcall MainView::frontBufferAvailableChanged(BOOL nowAvailable)
 {
-    // We'll implement this later.
+    if (!nowAvailable)
+        releaseResources();
     return S_OK;
 }

--- a/SlicerCore/src/Rendering/RenderBasics/Direct3D.cpp
+++ b/SlicerCore/src/Rendering/RenderBasics/Direct3D.cpp
@@ -1,14 +1,9 @@
-#pragma once
-#include "direct3D.h"
-#include <d3d11.h>
-#include <d3d9.h>
-#include <wrl/client.h> 
-#include <atlcomcli.h>
-#include "Direct3D.h" // The header file you already have
+#include "pch.h"
+#include "Direct3D.h"
 
-#pragma comment( lib, "D3D11.lib" )
-#pragma comment( lib, "D3D9.lib" )
-#pragma comment( lib, "DXGI.lib" )
+#pragma comment(lib, "D3D11.lib")
+#pragma comment(lib, "D3D9.lib")
+#pragma comment(lib, "DXGI.lib")
 
 namespace Direct3D
 {

--- a/SlicerCore/src/Rendering/RenderBasics/ViewBase.cpp
+++ b/SlicerCore/src/Rendering/RenderBasics/ViewBase.cpp
@@ -1,3 +1,4 @@
+#include "pch.h"
 #include "ViewBase.h"
 
 using namespace Direct3D;
@@ -24,6 +25,9 @@ HRESULT ViewBase::createResources(UINT width, UINT height)
 {
     // First, release any old resources.
     releaseResources();
+
+    m_width = width;
+    m_height = height;
 
     // Use the global Direct3D::device to create our resources.
     if (!Direct3D::device || !Direct3D::device9)
@@ -56,11 +60,30 @@ HRESULT ViewBase::createResources(UINT width, UINT height)
     hr = dxgiResource->GetSharedHandle(&m_sharedTextureHandle);
     if (FAILED(hr)) return hr;
 
+    // --- Create Depth/Stencil ---
+    D3D11_TEXTURE2D_DESC depthDesc = {};
+    depthDesc.Width = width;
+    depthDesc.Height = height;
+    depthDesc.MipLevels = 1;
+    depthDesc.ArraySize = 1;
+    depthDesc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
+    depthDesc.SampleDesc.Count = 1;
+    depthDesc.Usage = D3D11_USAGE_DEFAULT;
+    depthDesc.BindFlags = D3D11_BIND_DEPTH_STENCIL;
+
+    Microsoft::WRL::ComPtr<ID3D11Texture2D> depthTexture;
+    hr = Direct3D::device->CreateTexture2D(&depthDesc, nullptr, &depthTexture);
+    if (FAILED(hr)) return hr;
+
+    hr = Direct3D::device->CreateDepthStencilView(depthTexture.Get(), nullptr, &m_depthStencilView);
+    if (FAILED(hr)) return hr;
+
     // --- Create the Shared DX9 Surface ---
+    Microsoft::WRL::ComPtr<IDirect3DTexture9> d3d9Texture;
     hr = Direct3D::device9->CreateTexture(width, height, 1, D3DUSAGE_RENDERTARGET,
-        D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &m_sharedSurface, &m_sharedTextureHandle);
+        D3DFMT_A8R8G8B8, D3DPOOL_DEFAULT, &d3d9Texture, &m_sharedTextureHandle);
+    if (FAILED(hr)) return hr;
 
-    // (Depth buffer creation would go here as well)
-
+    hr = d3d9Texture->GetSurfaceLevel(0, &m_sharedSurface);
     return hr;
 }

--- a/SlicerCore/src/Rendering/RenderBasics/ViewBase.h
+++ b/SlicerCore/src/Rendering/RenderBasics/ViewBase.h
@@ -20,4 +20,8 @@ protected:
     Microsoft::WRL::ComPtr<ID3D11DepthStencilView> m_depthStencilView;
     Microsoft::WRL::ComPtr<IDirect3DSurface9> m_sharedSurface;
     HANDLE m_sharedTextureHandle = nullptr;
+
+    // cached size of the current render target
+    UINT m_width = 0;
+    UINT m_height = 0;
 };

--- a/SlicerCore/src/Rendering/RenderBasics/pch.h
+++ b/SlicerCore/src/Rendering/RenderBasics/pch.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <windows.h>
 
 #include <stdint.h>
@@ -9,6 +11,7 @@
 #include <atlcoll.h>
 #include <atlstr.h>
 #include <atltypes.h>
+#include <atlbase.h>
 #include <atlcom.h>
 #include <atlfile.h>
 
@@ -16,5 +19,6 @@
 #include <d3d9.h>
 #include <d3d12.h>
 
-#include <wrl/client.h> 
-#include <atlcomcli.h> 
+#include <wrl/client.h>
+#include <atlcomcli.h>
+


### PR DESCRIPTION
## Summary
- create and share Direct3D 11/9 resources
- add depth/stencil and viewport handling for rendering
- handle lost WPF front buffer resources

## Testing
- `msbuild AxoSlicer/AxoSlicer.sln` *(fails: command not found)*
- `dotnet build AxoSlicer/AxoSlicer.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68963e59caa08327881596a4ffccb5f1